### PR TITLE
updated w/ proper PPA; added sudo to commands

### DIFF
--- a/download.html
+++ b/download.html
@@ -61,13 +61,13 @@ layout: default
       </p>
       <ol>
         <li>
-          Run <code>add-apt-repository ppa:jerzy-kozera/zeal-ppa</code>
+          Run <code>sudo add-apt-repository ppa:zeal-developers/ppa</code>
         </li>
         <li>
-          then do <code>apt-get update</code>,
+          then do <code>sudo apt-get update</code>,
         </li>
         <li>
-          and <code>apt-get install zeal</code>
+          and <code>sudo apt-get install zeal</code>
         </li>
       </ol>
       After installing Zeal can be started from command line by running


### PR DESCRIPTION
Hi was just installing Zeal, followed the Ubuntu instructions, and got a warning that I was pointing at the wrong PPA, fixed it in the docs.
