### PR TITLE
Usage: Remove `--query`

### DIFF
--- a/usage.html
+++ b/usage.html
@@ -75,8 +75,8 @@ title: Usage
     Or you can use <a href="https://github.com/keith/investigate.vim">https://github.com/keith/investigate.vim</a>
     with something like this in .vimrc:
   </p>
-  <pre><code>let g:investigate_command_for_python = '/usr/bin/zeal dash://^s'</code></pre>
+  <pre><code>let g:investigate_command_for_python = '/usr/bin/zeal ^s'</code></pre>
 
   <p>A simpler way to integrate with Vim is a simple mapping, like</p>
-  <pre><code>:nnoremap gz :!zeal dash://"&lt;cword&gt;"&amp;&lt;CR&gt;&lt;CR&gt;</code></pre>
+  <pre><code>:nnoremap gz :!zeal "&lt;cword&gt;"&amp;&lt;CR&gt;&lt;CR&gt;</code></pre>
 </div>

--- a/usage.html
+++ b/usage.html
@@ -75,8 +75,8 @@ title: Usage
     Or you can use <a href="https://github.com/keith/investigate.vim">https://github.com/keith/investigate.vim</a>
     with something like this in .vimrc:
   </p>
-  <pre><code>let g:investigate_command_for_python = '/usr/bin/zeal --query ^s'</code></pre>
+  <pre><code>let g:investigate_command_for_python = '/usr/bin/zeal dash://^s'</code></pre>
 
   <p>A simpler way to integrate with Vim is a simple mapping, like</p>
-  <pre><code>:nnoremap gz :!zeal --query "&lt;cword&gt;"&amp;&lt;CR&gt;&lt;CR&gt;</code></pre>
+  <pre><code>:nnoremap gz :!zeal dash://"&lt;cword&gt;"&amp;&lt;CR&gt;&lt;CR&gt;</code></pre>
 </div>


### PR DESCRIPTION
`--query` parameter was removed in commit [4e8717f](https://github.com/zealdocs/zeal/commit/4e8717f8ebc98cc81f359529b0ef0153eff3edc6).
