### PR TITLE
Update link to Fedora package

### DIFF
--- a/download.html
+++ b/download.html
@@ -83,7 +83,7 @@ lead: There are various ways to download Zeal, depending on which operating
   <h3 id="linux-fedora">Fedora</h3>
   <p>Install Zeal from the official Fedora software repositories.</p>
   <pre>$ sudo dnf install zeal</pre>
-  <a href="https://admin.fedoraproject.org/pkgdb/package/rpms/zeal/"
+  <a href="https://apps.fedoraproject.org/packages/zeal"
      class="btn btn-default" role="button">View Fedora package</a>
 
   <h3 id="linux-gentoo">Gentoo</h3>


### PR DESCRIPTION
Looks like the old link was outdated and returned a `404`, so I found the link to the current Fedora repository database.