### PR TITLE
Add CODEOWNERS file.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# This file allows automatic assignment of pull requests.
+# See https://help.github.com/articles/about-codeowners/
+
+*       oleg@zealdocs.org


### PR DESCRIPTION
This file was copied directly from the main zeal repository.

I didn't see any reason why this shouldn't follow the same CODEOWNERS setup as the primary repository and having a reviewer assigned gives some piece of mind to contributors, I think. :)