### PR TITLE
docs(download): fix Arch installation instructions

### DIFF
--- a/download.html
+++ b/download.html
@@ -78,8 +78,9 @@ lead: There are various ways to download Zeal, depending on which operating
   </p>
 
   <h3 id="linux-arch">Arch Linux</h3>
-  <p>Arch Linux users can either install Zeal from the community repository:</p>
-  <pre>$ sudo pacman -Syu zeal</pre>
+  <p>Arch Linux users can install <code>zeal</code> from AUR</p>
+  <a href="https://aur.archlinux.org/packages/zeal/"
+     class="btn btn-default" role="button">View zeal in AUR</a>
   <p>Or use the <code>zeal-git</code> AUR package which builds unstable source code from our Git repository.</p>
   <a href="https://aur.archlinux.org/packages/zeal-git/"
      class="btn btn-default" role="button">View zeal-git in AUR</a>


### PR DESCRIPTION
This changes is connected with https://github.com/zealdocs/zeal-packaging/issues/46 and https://github.com/zealdocs/zeal/issues/1306