### PR TITLE
fix(download): update the installation instruction for Gentoo Linux

### DIFF
--- a/download.html
+++ b/download.html
@@ -102,8 +102,8 @@ lead: There are various ways to download Zeal, depending on which operating
 
   <h3 id="linux-gentoo">Gentoo</h3>
   <p>Install the official Zeal package for Gentoo:</p>
-  <pre># emerge app-doc/zeal</pre>
-  <a href="https://packages.gentoo.org/packages/app-doc/zeal"
+  <pre># emerge app-text/zeal</pre>
+  <a href="https://packages.gentoo.org/packages/app-text/zeal"
      class="btn btn-default" role="button">View Gentoo package</a>
 
   <h3 id="linux-opensuse">openSUSE</h3>


### PR DESCRIPTION
Dear Dev, 

Just came across a bit of [out-of-date info][1] on the Zeal's official site with regard to downloading/installing Zeal on Gentoo Linux.

The package has been renamed to app-text/zeal [^1]

[1]: https://zealdocs.org/download.html
[^1]: https://packages.gentoo.org/packages/app-text/zeal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected package category reference in download links to ensure users are directed to the appropriate package repository, providing accurate access for proper installation and system compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->